### PR TITLE
Upgrade Log4J 2.16.0 to 2.17.0

### DIFF
--- a/camunda-embedded-engine-demo-model/pom.xml
+++ b/camunda-embedded-engine-demo-model/pom.xml
@@ -43,7 +43,7 @@
       <guava.version>28.1-jre</guava.version>
       <junit.jupiter.version>5.4.0</junit.jupiter.version>
       <mockito.version>3.1.0</mockito.version>
-      <log4j.version>2.16.0</log4j.version>
+      <log4j.version>2.17.0</log4j.version>
       <slf4j.version>1.7.28</slf4j.version>
       <!-- ============================================== -->
       <!-- ================= MAVEN SITE ================= -->


### PR DESCRIPTION
Motivation:

Log4J upgrade to address a security risk CVE-2021-45105

Modifications:

Upgrade from 2.16.0 to 2.17.0

Result:

Using a safer Log4J version